### PR TITLE
Team entity added

### DIFF
--- a/src/main/java/cz/fi/muni/pa165/esports/dao/TeamDao.java
+++ b/src/main/java/cz/fi/muni/pa165/esports/dao/TeamDao.java
@@ -1,0 +1,19 @@
+package cz.fi.muni.pa165.esports.dao;
+
+import cz.fi.muni.pa165.esports.entity.Team;
+
+import java.util.List;
+
+/**
+ * @author Gabriela Kandova
+ */
+
+public interface TeamDao {
+    void create(Team team);
+    void delete(Team team);
+
+    Team findById(Long id);
+    List<Team> findAll();
+    Team findByName(String name);
+    Team findByAbbreviation(String abbreviation);
+}

--- a/src/main/java/cz/fi/muni/pa165/esports/dao/TeamDaoImpl.java
+++ b/src/main/java/cz/fi/muni/pa165/esports/dao/TeamDaoImpl.java
@@ -1,0 +1,59 @@
+package cz.fi.muni.pa165.esports.dao;
+
+import cz.fi.muni.pa165.esports.entity.Team;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+
+/**
+ * @author Gabriela Kandova
+ */
+
+@Repository
+public class TeamDaoImpl implements TeamDao {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public void create(Team team) {
+        em.persist(team);
+    }
+
+    @Override
+    public void delete(Team team) {
+        em.remove(team);
+    }
+
+    @Override
+    public Team findById(Long id) {
+        return em.find(Team.class, id);
+    }
+
+    @Override
+    public List<Team> findAll() {
+        return em.createQuery("select t from Team t", Team.class).getResultList();
+    }
+
+    @Override
+    public Team findByName(String name) {
+        try {
+            return em.createQuery("select t from Team t where t.name = :name", Team.class)
+                    .setParameter("name", name).getSingleResult();
+        } catch (NoResultException nre) {
+            return null;
+        }
+    }
+
+    @Override
+    public Team findByAbbreviation(String abbreviation) {
+        try {
+            return em.createQuery("select t from Team t where t.abbreviation = :abbr", Team.class)
+                    .setParameter("abbr", abbreviation).getSingleResult();
+        } catch (NoResultException nre) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
+++ b/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
@@ -1,4 +1,70 @@
 package cz.fi.muni.pa165.esports.entity;
 
+import javax.persistence.*;
+import java.util.Set;
+import java.util.HashSet;
+
+/**
+ * Team is an entity that represents an eSports team.
+ * A team consists of players and participates in competitions.
+ *
+ * @author Gabriela Kandova
+ */
+
+@Entity
 public class Team {
+    public Team(Long id) {
+        this.id = id;
+    }
+
+    public Team() {
+    }
+
+    /* attributes */
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String abbreviation;
+
+    private String description;
+
+    private Set<Player> players = new HashSet<>();
+
+    /* getters and setters */
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAbbreviation() {
+        return abbreviation;
+    }
+
+    public void setAbbreviation(String abbreviation) {
+        this.abbreviation = abbreviation;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
+++ b/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
@@ -35,6 +35,7 @@ public class Team {
 
     private String description;
 
+    @OneToMany(mappedBy = "team")
     private Set<Player> players = new HashSet<>();
 
     /* getters and setters */

--- a/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
+++ b/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
@@ -27,8 +27,10 @@ public class Team {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true, nullable = false)
     private String name;
 
+    @Column(unique = true, nullable = false)
     private String abbreviation;
 
     private String description;

--- a/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
+++ b/src/main/java/cz/fi/muni/pa165/esports/entity/Team.java
@@ -1,6 +1,7 @@
 package cz.fi.muni.pa165.esports.entity;
 
 import javax.persistence.*;
+import java.util.Objects;
 import java.util.Set;
 import java.util.HashSet;
 
@@ -66,5 +67,18 @@ public class Team {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Team)) return false;
+        Team team = (Team) o;
+        return getName().equals(team.getName()) && getAbbreviation().equals(team.getAbbreviation());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getAbbreviation());
     }
 }


### PR DESCRIPTION
So I implemented the Team entity according to the latest class diagram.

I set the `name` and `abbreviation` attributes to be unique and not null, and set up `equals()` and `hashCode()` to use those two attributes only. I believe one of them would be enough, but why not use both, right?

`mvn clean compile` passed for me.

Solves #9.

**TODOs:**
- [x] Implement entity
- [x] Add DAO interface
- [x] Add DAO implementation
- [ ] Add _proper_ Javadoc to DAO interface and implementation