### PR TITLE
Cleanup in PlayerDaoTest

### DIFF
--- a/src/test/java/cz/fi/muni/pa165/esports/dao/PlayerDaoTest.java
+++ b/src/test/java/cz/fi/muni/pa165/esports/dao/PlayerDaoTest.java
@@ -197,6 +197,15 @@ public class PlayerDaoTest extends AbstractTestNGSpringContextTests {
 
     @AfterClass
     private void cleanUp() {
+        em.getTransaction().begin();
+        em.createQuery("delete from Player where player_id in (:p1, :p2, :p3, :p4)")
+                .setParameter("p1", mrWhite.getPlayer_id())
+                .setParameter("p2", mrOrange.getPlayer_id())
+                .setParameter("p3", mrBlonde.getPlayer_id())
+                .setParameter("p4", mrsRed.getPlayer_id())
+                .executeUpdate();
+        em.getTransaction().commit();
+
         if (em != null) {
             em.close();
         }

--- a/src/test/java/cz/fi/muni/pa165/esports/dao/PlayerDaoTest.java
+++ b/src/test/java/cz/fi/muni/pa165/esports/dao/PlayerDaoTest.java
@@ -50,6 +50,8 @@ public class PlayerDaoTest extends AbstractTestNGSpringContextTests {
         em = emf.createEntityManager();
         em.getTransaction().begin();
 
+        em.createQuery("delete from Player").executeUpdate();
+
         mrWhite = new Player();
         mrWhite.setName("Larry");
         mrWhite.setAge(50);


### PR DESCRIPTION
- Since persisted entitiies persist between tests, I added the deletion of `Player` entities persisted in `PlayerDaoTest` during after class cleanup.
- I also added a delete of all `Player` entities in before class setup method, but this could be reverted once all tests clean up after themselves.