### PR TITLE
TeamService, EsportsServiceException

### DIFF
--- a/esports-api/src/main/java/cz/muni/fi/pa165/esports/exceptions/EsportsServiceException.java
+++ b/esports-api/src/main/java/cz/muni/fi/pa165/esports/exceptions/EsportsServiceException.java
@@ -1,0 +1,27 @@
+package cz.muni.fi.pa165.esports.exceptions;
+
+/**
+ * @author Gabriela Kandova
+ */
+public class EsportsServiceException extends RuntimeException {
+    public EsportsServiceException() {
+        super();
+    }
+
+    public EsportsServiceException(String message, Throwable cause,
+                                   boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+    public EsportsServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EsportsServiceException(String message) {
+        super(message);
+    }
+
+    public EsportsServiceException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/esports-service/pom.xml
+++ b/esports-service/pom.xml
@@ -16,5 +16,10 @@
             <artifactId>esports-persistence</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>cz.muni.fi.pa165</groupId>
+            <artifactId>esports-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 </project>

--- a/esports-service/src/main/java/cz/muni/fi/pa165/esports/service/TeamService.java
+++ b/esports-service/src/main/java/cz/muni/fi/pa165/esports/service/TeamService.java
@@ -1,18 +1,76 @@
 package cz.muni.fi.pa165.esports.service;
 
-import cz.muni.fi.pa165.esports.entity.Competition;
-import cz.muni.fi.pa165.esports.entity.MatchRecord;
 import cz.muni.fi.pa165.esports.entity.Player;
+import cz.muni.fi.pa165.esports.entity.Team;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * An interface that defines service access to the {@link Team} entity.
+ *
+ * @author Gabriela Kandova
+ */
+@Service
 public interface TeamService {
+    /**
+     * Fetch all teams registered in the system.
+     *
+     * @return a list of all teams
+     */
+    List<Team> findAll();
 
-    boolean applyForCompetition(Competition competition);
+    /**
+     * Fetch a registered team according to its ID.
+     *
+     * @param id unique ID of a team
+     * @return team with the given ID, NULL if not found
+     */
+    Team findById(Long id);
 
-    void acceptPlayer(Player player);
+    /**
+     * Fetch a registered team according to its name.
+     *
+     * @param name unique name of a team
+     * @return team with the given name, NULL if not found
+     */
+    Team findByName(String name);
 
-    List<Player> getPlayers();
+    /**
+     * Fetch a registered team according to its abbreviation.
+     *
+     * @param abbreviation unique abbreviation of a team
+     * @return team with the given abbreviation, NULL if not found
+     */
+    Team findByAbbreviation(String abbreviation);
 
-    void getTeamStatistics();
+    /**
+     * Register a team in the system.
+     *
+     * @param team team to be registered
+     */
+    void create(Team team);
+
+    /**
+     * Remove a team from the system.
+     *
+     * @param team team to be removed
+     */
+    void remove(Team team);
+
+    /**
+     * Add a player to a team if the player is free.
+     *
+     * @param team   team to accept the player
+     * @param player player to join the team
+     */
+    void addPlayer(Team team, Player player);
+
+    /**
+     * Remove a player from a team.
+     *
+     * @param team   team from which to remove the player
+     * @param player player to remove from the team
+     */
+    void removePlayer(Team team, Player player);
 }

--- a/esports-service/src/main/java/cz/muni/fi/pa165/esports/service/TeamServiceImpl.java
+++ b/esports-service/src/main/java/cz/muni/fi/pa165/esports/service/TeamServiceImpl.java
@@ -1,29 +1,78 @@
 package cz.muni.fi.pa165.esports.service;
 
-import cz.muni.fi.pa165.esports.entity.Competition;
+import cz.muni.fi.pa165.esports.dao.TeamDao;
 import cz.muni.fi.pa165.esports.entity.Player;
+import cz.muni.fi.pa165.esports.entity.Team;
+import cz.muni.fi.pa165.esports.exceptions.EsportsServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+/**
+ * An implementation of the {@link TeamService}.
+ *
+ * @author Gabriela Kandova
+ */
+@Service
 public class TeamServiceImpl implements TeamService {
+    @Autowired
+    TeamDao teamDao;
 
     @Override
-    public boolean applyForCompetition(Competition competition) {
-        return false;
+    public List<Team> findAll() {
+        return teamDao.findAll();
     }
 
     @Override
-    public void acceptPlayer(Player player) {
-
+    public Team findById(Long id) {
+        return teamDao.findById(id);
     }
 
     @Override
-    public List<Player> getPlayers() {
-        return null;
+    public Team findByName(String name) {
+        return teamDao.findByName(name);
     }
 
     @Override
-    public void getTeamStatistics() {
+    public Team findByAbbreviation(String abbreviation) {
+        return teamDao.findByAbbreviation(abbreviation);
+    }
 
+    @Override
+    public void create(Team team) {
+        teamDao.create(team);
+    }
+
+    @Override
+    public void remove(Team team) {
+        teamDao.delete(team);
+    }
+
+    @Override
+    public void addPlayer(Team team, Player player) {
+        if (team.getPlayers().contains(player)) {
+            throw new EsportsServiceException(String.format(
+                    "Player %s is already member of team %s", player.getName(), team.getName()
+            ));
+        }
+        if (player.getTeam() != null) {
+            throw new EsportsServiceException(String.format(
+                    "Player %s is already member of team %s", player.getName(), player.getTeam().getName()
+            ));
+        }
+
+        team.addPlayer(player); // is this all that's necessary?
+    }
+
+    @Override
+    public void removePlayer(Team team, Player player) {
+        if (!team.getPlayers().contains(player)) {
+            throw new EsportsServiceException(String.format(
+                    "Player %s is not member of team %s", player.getName(), team.getName()
+            ));
+        }
+
+        team.removePlayer(player); // is this all that's necessary?
     }
 }


### PR DESCRIPTION
- defined and documented `TeamService`, implemented it in `TeamServiceImpl`
  - **CRUD operations only** for now, removed other methods
  - I am confused about the scope of the service layer
    - since Team does not have an attribute `competitions`, only `matchRecords` I don't know if it makes sense to enroll team in a competition through the `TeamService`
    - maybe we need an object for `TeamStatistics`, `PlayerStatistics`?
- created `EsportsServiceException` (inspired by the sample project)
- added `esports-api` to `esports-service` dependencies to use the exception

What do you think?

Please don't merge this PR for me, I'll merge it myself when everything is okay :smiley: 