### PR TITLE
Initial simple player service test

### DIFF
--- a/esports-service/pom.xml
+++ b/esports-service/pom.xml
@@ -37,6 +37,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.22.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>cz.muni.fi.pa165</groupId>
             <artifactId>esports-api</artifactId>
             <version>1.0-SNAPSHOT</version>

--- a/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
+++ b/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
@@ -1,7 +1,85 @@
 package cz.muni.fi.pa165.esports.service;
 
+import cz.muni.fi.pa165.esports.dao.PlayerDao;
+import cz.muni.fi.pa165.esports.entity.Player;
+import cz.muni.fi.pa165.esports.enums.Gender;
+import cz.muni.fi.pa165.esports.service.config.ServiceConfiguration;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.testng.Assert.*;
 
-public class PlayerServiceTest {
+@ContextConfiguration(classes = {ServiceConfiguration.class})
+public class PlayerServiceTest extends AbstractTestNGSpringContextTests {
+    @Mock
+    private PlayerDao playerDao;
 
+    @Autowired
+    @InjectMocks
+    private PlayerService playerService;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        Player alice = new Player();
+        alice.setId(1L);
+        alice.setName("Alice");
+        alice.setGender(Gender.FEMALE);
+
+        Player bob = new Player();
+        bob.setId(2L);
+        bob.setName("Bob");
+        bob.setGender(Gender.MALE);
+
+        List<Player> allPlayers = new ArrayList<>();
+        allPlayers.add(alice);
+        allPlayers.add(bob);
+
+        List<Player> aliceList = new ArrayList<>();
+        aliceList.add(alice);
+
+        List<Player> bobList = new ArrayList<>();
+        bobList.add(bob);
+
+        Mockito.when(playerDao.findAll()).thenReturn(allPlayers);
+        Mockito.when(playerDao.findByName("Alice")).thenReturn(aliceList);
+        Mockito.when(playerDao.findByName("Bob")).thenReturn(bobList);
+        Mockito.when(playerDao.findByGender(Gender.FEMALE)).thenReturn(aliceList);
+        Mockito.when(playerDao.findByGender(Gender.MALE)).thenReturn(bobList);
+        Mockito.when(playerDao.findById(alice.getId())).thenReturn(alice);
+        Mockito.when(playerDao.findById(bob.getId())).thenReturn(bob);
+    }
+
+    @Test
+    public void getAllPlayersTest() {
+        List<Player> allPlayers = playerService.getAllPlayers();
+
+        // expecting 2 players
+        assertEquals(allPlayers.size(), 2);
+        Player p1 = allPlayers.get(0);
+        assertNotNull(p1);
+        Player p2 = allPlayers.get(1);
+        assertNotNull(p2);
+
+        // assert that player ids, names and genders are different
+        assertNotEquals(p1.getId(), p2.getId());
+        assertNotEquals(p1.getName(), p2.getName());
+        assertNotEquals(p1.getGender(), p2.getGender());
+
+        // assert that bob and alice are present
+        // the assertion above guarantees XOR
+        assertTrue(p1.getName().equals("Alice") || p2.getName().equals("Alice"));
+        assertTrue(p1.getName().equals("Bob") || p2.getName().equals("Bob"));
+    }
 }

--- a/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
+++ b/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
@@ -58,17 +59,42 @@ public class PlayerServiceTest extends AbstractTestNGSpringContextTests {
 
         Mockito.when(playerDao.findAll()).thenReturn(allPlayers);
 
-        Mockito.when(playerDao.findByName("Alice")).thenReturn(aliceList);
-        Mockito.when(playerDao.findByName("Bob")).thenReturn(bobList);
-        Mockito.when(playerDao.findByName(Mockito.anyString())).thenReturn(new ArrayList<>());
+        // Inspired by https://stackoverflow.com/a/22345982
+        Mockito.when(playerDao.findByName(Mockito.anyString())).thenAnswer(
+                (Answer<List<Player>>) invocationOnMock -> {
+                    if ("Alice".equals(invocationOnMock.getArgument(0))) {
+                        return aliceList;
+                    }
+                    if ("Bob".equals(invocationOnMock.getArgument(0))) {
+                        return bobList;
+                    }
+                    return new ArrayList<>();
+                }
+        );
 
-        Mockito.when(playerDao.findByGender(Gender.FEMALE)).thenReturn(aliceList);
-        Mockito.when(playerDao.findByGender(Gender.MALE)).thenReturn(bobList);
-        Mockito.when(playerDao.findByGender(Gender.OTHER)).thenReturn(new ArrayList<>());
+        Mockito.when(playerDao.findByGender(Mockito.any(Gender.class))).thenAnswer(
+                (Answer<List<Player>>) invocationOnMock -> {
+                    if (Gender.FEMALE.equals(invocationOnMock.getArgument(0))) {
+                        return aliceList;
+                    }
+                    if (Gender.FEMALE.equals(invocationOnMock.getArgument(0))) {
+                        return bobList;
+                    }
+                    return new ArrayList<>();
+                }
+        );
 
-        Mockito.when(playerDao.findById(alice.getId())).thenReturn(alice);
-        Mockito.when(playerDao.findById(bob.getId())).thenReturn(bob);
-        Mockito.when(playerDao.findById(Mockito.anyLong())).thenReturn(null);
+        Mockito.when(playerDao.findById(Mockito.anyLong())).thenAnswer(
+                (Answer<Player>)  invocationOnMock -> {
+                    if (Long.valueOf(1).equals(invocationOnMock.getArgument(0))) {
+                        return alice;
+                    }
+                    if (Long.valueOf(2).equals(invocationOnMock.getArgument(0))) {
+                        return bob;
+                    }
+                    return null;
+                }
+        );
     }
 
     @Test

--- a/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
+++ b/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
@@ -57,12 +57,18 @@ public class PlayerServiceTest extends AbstractTestNGSpringContextTests {
         bobList.add(bob);
 
         Mockito.when(playerDao.findAll()).thenReturn(allPlayers);
+
         Mockito.when(playerDao.findByName("Alice")).thenReturn(aliceList);
         Mockito.when(playerDao.findByName("Bob")).thenReturn(bobList);
+        Mockito.when(playerDao.findByName(Mockito.anyString())).thenReturn(new ArrayList<>());
+
         Mockito.when(playerDao.findByGender(Gender.FEMALE)).thenReturn(aliceList);
         Mockito.when(playerDao.findByGender(Gender.MALE)).thenReturn(bobList);
+        Mockito.when(playerDao.findByGender(Gender.OTHER)).thenReturn(new ArrayList<>());
+
         Mockito.when(playerDao.findById(alice.getId())).thenReturn(alice);
         Mockito.when(playerDao.findById(bob.getId())).thenReturn(bob);
+        Mockito.when(playerDao.findById(Mockito.anyLong())).thenReturn(null);
     }
 
     @Test

--- a/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
+++ b/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
@@ -118,4 +118,57 @@ public class PlayerServiceTest extends AbstractTestNGSpringContextTests {
         assertTrue(p1.getName().equals("Alice") || p2.getName().equals("Alice"));
         assertTrue(p1.getName().equals("Bob") || p2.getName().equals("Bob"));
     }
+
+    @Test
+    public void findByIdFoundTest() {
+        Player foundPlayer = playerService.findById(1L);
+        assertNotNull(foundPlayer);
+        assertEquals(foundPlayer.getName(), "Alice");
+        assertEquals(foundPlayer.getGender(), Gender.FEMALE);
+        assertEquals(foundPlayer.getId(), Long.valueOf(1));
+
+        foundPlayer = playerService.findById(2L);
+        assertNotNull(foundPlayer);
+        assertEquals(foundPlayer.getName(), "Bob");
+        assertEquals(foundPlayer.getGender(), Gender.MALE);
+        assertEquals(foundPlayer.getId(), Long.valueOf(2));
+    }
+
+    @Test
+    public void findByIdNotFoundTest() {
+        Player foundPlayer = playerService.findById(3L);
+        assertNull(foundPlayer);
+    }
+
+    @Test
+    public void findByNameFoundSingleTest() {
+        String name = "Alice";
+        List<Player> foundPlayers = playerService.findByName(name);
+        assertEquals(foundPlayers.size(), 1);
+        assertNotNull(foundPlayers.get(0));
+        assertEquals(foundPlayers.get(0).getName(), name);
+        assertEquals(foundPlayers.get(0).getGender(), Gender.FEMALE);
+    }
+
+    @Test
+    public void findByNameNotFoundTest() {
+        List<Player> foundPlayers = playerService.findByName("Cecil");
+        assertEquals(foundPlayers.size(), 0);
+    }
+
+    @Test
+    public void findByNameFoundMultipleTest() {
+    }
+
+    @Test
+    public void createTest() {
+    }
+
+    @Test
+    public void removeTest() {
+    }
+
+    @Test
+    public void getPlayerStatisticsTest() {
+    }
 }

--- a/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
+++ b/esports-service/src/test/java/cz/muni/fi/pa165/esports/service/PlayerServiceTest.java
@@ -19,6 +19,10 @@ import java.util.List;
 
 import static org.testng.Assert.*;
 
+/**
+ * Unit tests for {@link PlayerService}
+ * @author Gabriela Kandova
+ */
 @ContextConfiguration(classes = {ServiceConfiguration.class})
 public class PlayerServiceTest extends AbstractTestNGSpringContextTests {
     @Mock


### PR DESCRIPTION
**Summary and notes:**

- Added Mockito dependency in test scope
- Mock DAO that the service is using, set up behavior in `setup` method
  - It's necessary to also set up IDs for the entity objects as we're not going through hibernate this time
  - Maybe there should also be a setting that `playerDao` should return `null` for any other input
  - I tried setting up the mock behavior in another `@BeforeClass` method, but it somehow ran before `initMocks` and threw a `NullPointerException`